### PR TITLE
fix(scoring): show candidate name instead of raw id on AI Scoring rankings

### DIFF
--- a/packages/server/src/services/scoring/resume-scoring.service.ts
+++ b/packages/server/src/services/scoring/resume-scoring.service.ts
@@ -467,10 +467,17 @@ export async function getJobRankings(
   if (!job) throw new NotFoundError("Job", jobId);
 
   const rows = await db.raw<any[][]>(
-    `SELECT cs.*, c.first_name as candidate_first_name, c.last_name as candidate_last_name, c.email as candidate_email, a.stage as application_stage
+    `SELECT cs.*,
+            c.first_name as candidate_first_name,
+            c.last_name as candidate_last_name,
+            TRIM(CONCAT(COALESCE(c.first_name,''), ' ', COALESCE(c.last_name,''))) as candidate_name,
+            c.email as candidate_email,
+            j.title as job_title,
+            a.stage as application_stage
      FROM candidate_scores cs
      LEFT JOIN candidates c ON c.id = cs.candidate_id
      LEFT JOIN applications a ON a.id = cs.application_id
+     LEFT JOIN job_postings j ON j.id = cs.job_id
      WHERE cs.organization_id = ? AND cs.job_id = ?
      ORDER BY cs.overall_score DESC`,
     [orgId, jobId],


### PR DESCRIPTION
## Summary
Fixes **#25** â€” AI Scoring rankings were rendering `Candidate #<uuid>` instead of the candidate's full name.

## Root cause
The rankings SQL selected `c.first_name as candidate_first_name` and `c.last_name as candidate_last_name` from the `candidates` join, but [ScoringPage.tsx](packages/client/src/pages/scoring/ScoringPage.tsx) reads `r.candidate_name`. With no `candidate_name` on the payload, the fallback `Candidate #${r.candidate_id}` kicked in on every row.

## Fix
Add a concatenated `candidate_name` to the rankings query and also surface `job_title` so downstream UI doesn't need a second fetch.

```sql
SELECT cs.*,
       c.first_name  as candidate_first_name,
       c.last_name   as candidate_last_name,
       TRIM(CONCAT(COALESCE(c.first_name,''), ' ',
                   COALESCE(c.last_name,''))) as candidate_name,
       c.email       as candidate_email,
       j.title       as job_title,
       a.stage       as application_stage
  FROM candidate_scores cs
  LEFT JOIN candidates c ON c.id = cs.candidate_id
  LEFT JOIN applications a ON a.id = cs.application_id
  LEFT JOIN job_postings j ON j.id = cs.job_id
 WHERE cs.organization_id = ? AND cs.job_id = ?
 ORDER BY cs.overall_score DESC
```

Backward-compatible: `candidate_first_name` / `candidate_last_name` still returned for any other consumers.

## Files
- `packages/server/src/services/scoring/resume-scoring.service.ts` (+8 / âˆ’1)

## Test plan
- [ ] `/scoring` â†’ select a job with scored applicants â†’ each row shows the candidate's real name (e.g. "Aditya Mehra"), not "Candidate #<uuid>"
- [ ] Candidates with missing `first_name` OR `last_name` still render whichever half is present (TRIM + COALESCE)

Closes #25
