### PR TITLE
fix(dashboard): Total Applications card now navigates to Candidates, not Jobs

### DIFF
--- a/packages/client/src/pages/dashboard/DashboardPage.tsx
+++ b/packages/client/src/pages/dashboard/DashboardPage.tsx
@@ -128,7 +128,10 @@ export function DashboardPage() {
       value: totalApplications,
       icon: FileText,
       color: "bg-blue-50 text-blue-600",
-      link: "/jobs",
+      // #10 — was `/jobs`, which dropped the user on the Job Posting tab.
+      // Applications are browsed through candidates until a dedicated
+      // /applications list page ships.
+      link: "/candidates",
     },
     {
       label: "Total Jobs",


### PR DESCRIPTION
## Summary
Fixes **#10** â€” the "Total Applications" stat card on the dashboard redirected to the Job Postings tab.

## Fix
Change the stat card's `link` from `/jobs` to `/candidates`. Applications are currently browsed through candidate detail pages; this at least lands the user in the right neighborhood instead of a list of job postings.

A dedicated `/applications` list page is a reasonable next step (would also help #28 â€” "Recent Applications should be clickable") but is out of scope for this one-line fix.

## Files
- `packages/client/src/pages/dashboard/DashboardPage.tsx` (+4 / âˆ’1)

## Test plan
- [ ] `/dashboard` â†’ click **Total Applications** card â†’ lands on `/candidates`, not `/jobs`
- [ ] Other stat cards (Active Jobs, Total Candidates, Total Jobs) still link to their respective pages

Closes #10
