### PR TITLE
fix(candidates): detail page no longer crashes to blank on click

### DIFF
--- a/packages/client/src/pages/candidates/CandidateDetailPage.tsx
+++ b/packages/client/src/pages/candidates/CandidateDetailPage.tsx
@@ -66,8 +66,24 @@ export function CandidateDetailPage() {
     );
   }
 
-  const skills = candidate.skills ? JSON.parse(candidate.skills) as string[] : [];
-  const tags = candidate.tags ? JSON.parse(candidate.tags) as string[] : [];
+  // #15 — mysql2 returns JSON columns as already-parsed arrays. Calling
+  // JSON.parse on an array throws, which crashed this page to blank after
+  // clicking a candidate. Handle array | string | null defensively.
+  const parseJsonArray = (v: unknown): string[] => {
+    if (!v) return [];
+    if (Array.isArray(v)) return v as string[];
+    if (typeof v === "string") {
+      try {
+        const parsed = JSON.parse(v);
+        return Array.isArray(parsed) ? parsed : [];
+      } catch {
+        return [];
+      }
+    }
+    return [];
+  };
+  const skills = parseJsonArray(candidate.skills);
+  const tags = parseJsonArray(candidate.tags);
 
   return (
     <div className="space-y-6">


### PR DESCRIPTION
## Summary
Fixes **#15** â€” clicking a candidate on `/candidates` navigated to a blank page.

## Root cause
`candidates.skills` and `candidates.tags` are MySQL JSON columns. The `mysql2` driver returns JSON columns as **already-parsed values** (arrays / objects), but CandidateDetailPage called `JSON.parse` on them again:

```ts
const skills = candidate.skills ? JSON.parse(candidate.skills) as string[] : [];
const tags   = candidate.tags   ? JSON.parse(candidate.tags)   as string[] : [];
```

`JSON.parse(["React", "Node.js"])` coerces the array to string `"React,Node.js"` and then throws `SyntaxError: Unexpected token ,`. The throw was unhandled during the initial render, so React crashed the whole subtree â€” hence the blank page.

## Fix
One local `parseJsonArray(v)` helper that handles `array | string | null` and returns `[]` on any failure path. Scoped to this page because the crash was specific to it; other pages (JobDetailPage, JobFormPage) already have the same defensive pattern.

## Files
- `packages/client/src/pages/candidates/CandidateDetailPage.tsx` (+18 / âˆ’2)

## Test plan
- [ ] `/candidates` â†’ click any candidate â†’ detail page renders without blank
- [ ] Candidate with skills array â†’ skills chips render
- [ ] Candidate with tags array â†’ tag chips render
- [ ] Candidate with null skills / tags â†’ renders fine with empty sections
- [ ] Candidate with legacy string-JSON skills (if any) â†’ still parses correctly

Closes #15
