### PR TITLE
fix(offers): Edit + Submit for Approval + defensive approvers rendering

### DIFF
--- a/packages/client/src/pages/offers/OfferDetailPage.tsx
+++ b/packages/client/src/pages/offers/OfferDetailPage.tsx
@@ -85,9 +85,35 @@ export function OfferDetailPage() {
 
   const offer = data?.data;
 
+  // #21 — Submit for Approval state. The backend rejects an empty
+  // approver_ids array, so we now gather selected approvers from a modal
+  // picker and surface errors via toast.
+  const [showApproverModal, setShowApproverModal] = useState(false);
+  const [selectedApproverIds, setSelectedApproverIds] = useState<number[]>([]);
+
+  const { data: usersData } = useQuery({
+    queryKey: ["org-users"],
+    queryFn: () =>
+      apiGet<{ id: number; first_name: string; last_name: string; email: string; role: string; designation: string | null }[]>(
+        "/organizations/users",
+      ),
+    enabled: showApproverModal,
+  });
+  const orgUsers = usersData?.data ?? [];
+
   const submitApproval = useMutation({
-    mutationFn: () => apiPost(`/offers/${id}/submit-approval`, { approver_ids: [] }),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["offer", id] }),
+    mutationFn: (approver_ids: number[]) =>
+      apiPost(`/offers/${id}/submit-approval`, { approver_ids }),
+    onSuccess: () => {
+      toast.success("Offer submitted for approval");
+      setShowApproverModal(false);
+      setSelectedApproverIds([]);
+      queryClient.invalidateQueries({ queryKey: ["offer", id] });
+    },
+    onError: (err: any) => {
+      const msg = err?.response?.data?.error?.message || "Failed to submit for approval";
+      toast.error(msg);
+    },
   });
 
   const sendOffer = useMutation({
@@ -246,14 +272,19 @@ export function OfferDetailPage() {
         <div className="flex items-center gap-2">
           {offer.status === "draft" && (
             <>
+              {/* #21 — was linking to `/offers/:id` (the same detail page);
+                  now routes to a real edit page. */}
               <Link
-                to={`/offers/${id}`}
+                to={`/offers/${id}/edit`}
                 className="rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors"
               >
                 Edit
               </Link>
+              {/* #21 — was POSTing { approver_ids: [] }, which the server
+                  rejected with "At least one approver is required". Open a
+                  modal to pick approvers first. */}
               <button
-                onClick={() => submitApproval.mutate()}
+                onClick={() => setShowApproverModal(true)}
                 disabled={submitApproval.isPending}
                 className="inline-flex items-center gap-2 rounded-lg bg-yellow-600 px-4 py-2 text-sm font-medium text-white hover:bg-yellow-700 disabled:opacity-50 transition-colors"
               >
@@ -542,7 +573,9 @@ export function OfferDetailPage() {
         <div className="space-y-6">
           <div className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
             <h2 className="text-lg font-semibold text-gray-900">Approval Workflow</h2>
-            {offer.approvers.length === 0 ? (
+            {/* #22 — defensive: if the API ever returns offer without
+                `approvers` (e.g. older row shape), don't crash the render. */}
+            {(!Array.isArray(offer.approvers) || offer.approvers.length === 0) ? (
               <div className="mt-4 flex flex-col items-center justify-center py-8">
                 <Clock className="h-8 w-8 text-gray-300" />
                 <p className="mt-2 text-sm text-gray-500 text-center">
@@ -551,7 +584,7 @@ export function OfferDetailPage() {
               </div>
             ) : (
               <div className="mt-4 space-y-3">
-                {offer.approvers.map((approver, idx) => {
+                {(offer.approvers ?? []).map((approver, idx) => {
                   const aStatus = APPROVER_STATUS[approver.status] || APPROVER_STATUS.pending;
                   return (
                     <div
@@ -637,6 +670,87 @@ export function OfferDetailPage() {
           </div>
         </div>
       </div>
+
+      {/* #21 — Approver picker modal */}
+      {showApproverModal && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
+          <div className="w-full max-w-md rounded-xl bg-white shadow-xl">
+            <div className="flex items-center justify-between border-b border-gray-100 px-6 py-4">
+              <h3 className="text-base font-semibold text-gray-900">Submit for Approval</h3>
+              <button
+                onClick={() => {
+                  setShowApproverModal(false);
+                  setSelectedApproverIds([]);
+                }}
+                className="rounded-lg p-1.5 text-gray-400 hover:bg-gray-100 hover:text-gray-600"
+              >
+                <X className="h-4 w-4" />
+              </button>
+            </div>
+            <div className="px-6 py-4">
+              <p className="mb-3 text-sm text-gray-500">
+                Pick one or more approvers. They'll review this offer before it can be sent.
+              </p>
+              {orgUsers.length === 0 ? (
+                <p className="py-4 text-center text-sm text-gray-400">Loading users...</p>
+              ) : (
+                <div className="max-h-64 overflow-y-auto rounded-lg border border-gray-200">
+                  {orgUsers.map((u) => (
+                    <label
+                      key={u.id}
+                      className="flex cursor-pointer items-center gap-3 border-b border-gray-100 px-3 py-2 last:border-b-0 hover:bg-gray-50"
+                    >
+                      <input
+                        type="checkbox"
+                        checked={selectedApproverIds.includes(u.id)}
+                        onChange={(e) =>
+                          setSelectedApproverIds((prev) =>
+                            e.target.checked ? [...prev, u.id] : prev.filter((x) => x !== u.id),
+                          )
+                        }
+                      />
+                      <div className="min-w-0 flex-1">
+                        <p className="truncate text-sm font-medium text-gray-900">
+                          {u.first_name} {u.last_name}
+                        </p>
+                        <p className="truncate text-xs text-gray-500">
+                          {u.designation || u.role} · {u.email}
+                        </p>
+                      </div>
+                    </label>
+                  ))}
+                </div>
+              )}
+            </div>
+            <div className="flex justify-end gap-3 border-t border-gray-100 bg-gray-50 px-6 py-4 rounded-b-xl">
+              <button
+                type="button"
+                onClick={() => {
+                  setShowApproverModal(false);
+                  setSelectedApproverIds([]);
+                }}
+                className="rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  if (selectedApproverIds.length === 0) {
+                    toast.error("Please pick at least one approver");
+                    return;
+                  }
+                  submitApproval.mutate(selectedApproverIds);
+                }}
+                disabled={submitApproval.isPending}
+                className="rounded-lg bg-yellow-600 px-4 py-2 text-sm font-medium text-white hover:bg-yellow-700 disabled:opacity-50"
+              >
+                {submitApproval.isPending ? "Submitting..." : "Submit"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/client/src/pages/offers/OfferEditPage.tsx
+++ b/packages/client/src/pages/offers/OfferEditPage.tsx
@@ -1,0 +1,259 @@
+// #21 — there was no edit flow for draft offers. The Edit button on
+// OfferDetailPage previously linked to itself (`/offers/:id`), which did
+// nothing. This page loads the offer, renders the editable fields, and
+// submits via PUT /offers/:id. Only draft offers can be edited (the
+// server enforces this via `updateOffer`).
+
+import { useState, useEffect } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { ArrowLeft, Save, Loader2 } from "lucide-react";
+import { apiGet, apiPut } from "@/api/client";
+import toast from "react-hot-toast";
+import type { Offer } from "@emp-recruit/shared";
+
+interface FormData {
+  job_title: string;
+  department: string;
+  salary_amount: string;
+  salary_currency: string;
+  joining_date: string;
+  expiry_date: string;
+  benefits: string;
+  notes: string;
+}
+
+const INITIAL: FormData = {
+  job_title: "",
+  department: "",
+  salary_amount: "",
+  salary_currency: "INR",
+  joining_date: "",
+  expiry_date: "",
+  benefits: "",
+  notes: "",
+};
+
+export function OfferEditPage() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+
+  const [form, setForm] = useState<FormData>(INITIAL);
+
+  const { data: offerData, isLoading } = useQuery({
+    queryKey: ["offer", id],
+    queryFn: () => apiGet<Offer>(`/offers/${id}`),
+    enabled: Boolean(id),
+  });
+
+  // Pre-fill the form once the offer loads.
+  useEffect(() => {
+    const o = offerData?.data;
+    if (!o) return;
+    setForm({
+      job_title: o.job_title ?? "",
+      department: o.department ?? "",
+      salary_amount: String(o.salary_amount ?? ""),
+      salary_currency: o.salary_currency ?? "INR",
+      joining_date: (o.joining_date ?? "").slice(0, 10),
+      expiry_date: (o.expiry_date ?? "").slice(0, 10),
+      benefits: o.benefits ?? "",
+      notes: o.notes ?? "",
+    });
+  }, [offerData]);
+
+  const updateMutation = useMutation({
+    mutationFn: (data: Record<string, any>) => apiPut<Offer>(`/offers/${id}`, data),
+    onSuccess: () => {
+      toast.success("Offer updated");
+      queryClient.invalidateQueries({ queryKey: ["offer", id] });
+      queryClient.invalidateQueries({ queryKey: ["offers"] });
+      navigate(`/offers/${id}`);
+    },
+    onError: (err: any) => {
+      const msg = err?.response?.data?.error?.message || "Failed to update offer";
+      toast.error(msg);
+    },
+  });
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const payload: Record<string, any> = {
+      job_title: form.job_title,
+      salary_currency: form.salary_currency,
+    };
+    if (form.department) payload.department = form.department;
+    if (form.salary_amount) payload.salary_amount = Number(form.salary_amount);
+    if (form.joining_date) payload.joining_date = form.joining_date;
+    if (form.expiry_date) payload.expiry_date = form.expiry_date;
+    if (form.benefits) payload.benefits = form.benefits;
+    if (form.notes) payload.notes = form.notes;
+    updateMutation.mutate(payload);
+  }
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center py-12">
+        <Loader2 className="h-8 w-8 animate-spin text-brand-600" />
+      </div>
+    );
+  }
+
+  const offer = offerData?.data;
+  if (!offer) {
+    return (
+      <div className="py-12 text-center text-gray-500">Offer not found.</div>
+    );
+  }
+
+  if (offer.status !== "draft") {
+    return (
+      <div className="mx-auto max-w-3xl space-y-4">
+        <button
+          onClick={() => navigate(`/offers/${id}`)}
+          className="inline-flex items-center gap-2 rounded-lg p-2 text-gray-400 hover:bg-gray-100 hover:text-gray-600"
+        >
+          <ArrowLeft className="h-5 w-5" /> Back
+        </button>
+        <div className="rounded-lg border border-amber-200 bg-amber-50 p-6 text-sm text-amber-800">
+          Only draft offers can be edited. This offer is currently
+          <strong className="mx-1">{offer.status.replace("_", " ")}</strong>.
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-6">
+      <div className="flex items-center gap-4">
+        <button
+          onClick={() => navigate(`/offers/${id}`)}
+          className="rounded-lg p-2 text-gray-400 hover:bg-gray-100 hover:text-gray-600"
+        >
+          <ArrowLeft className="h-5 w-5" />
+        </button>
+        <h1 className="text-2xl font-bold text-gray-900">Edit Offer</h1>
+      </div>
+
+      <form onSubmit={handleSubmit} className="space-y-6">
+        <div className="rounded-lg border border-gray-200 bg-white p-6 space-y-4">
+          <h2 className="text-lg font-semibold text-gray-900">Offer Details</h2>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Job Title *</label>
+            <input
+              type="text"
+              required
+              value={form.job_title}
+              onChange={(e) => setForm((p) => ({ ...p, job_title: e.target.value }))}
+              className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Department</label>
+            <input
+              type="text"
+              value={form.department}
+              onChange={(e) => setForm((p) => ({ ...p, department: e.target.value }))}
+              className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500"
+            />
+          </div>
+
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">Salary *</label>
+              <input
+                type="number"
+                required
+                min={0}
+                value={form.salary_amount}
+                onChange={(e) => setForm((p) => ({ ...p, salary_amount: e.target.value }))}
+                className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">Currency</label>
+              <select
+                value={form.salary_currency}
+                onChange={(e) => setForm((p) => ({ ...p, salary_currency: e.target.value }))}
+                className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500"
+              >
+                <option value="INR">INR</option>
+                <option value="USD">USD</option>
+                <option value="EUR">EUR</option>
+                <option value="GBP">GBP</option>
+              </select>
+            </div>
+          </div>
+
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">Joining Date *</label>
+              <input
+                type="date"
+                required
+                value={form.joining_date}
+                onChange={(e) => setForm((p) => ({ ...p, joining_date: e.target.value }))}
+                className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">Expiry Date *</label>
+              <input
+                type="date"
+                required
+                value={form.expiry_date}
+                onChange={(e) => setForm((p) => ({ ...p, expiry_date: e.target.value }))}
+                className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500"
+              />
+            </div>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Benefits</label>
+            <textarea
+              value={form.benefits}
+              onChange={(e) => setForm((p) => ({ ...p, benefits: e.target.value }))}
+              rows={3}
+              className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Notes</label>
+            <textarea
+              value={form.notes}
+              onChange={(e) => setForm((p) => ({ ...p, notes: e.target.value }))}
+              rows={3}
+              className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500"
+            />
+          </div>
+        </div>
+
+        <div className="flex justify-end gap-3">
+          <button
+            type="button"
+            onClick={() => navigate(`/offers/${id}`)}
+            className="rounded-lg border border-gray-300 px-4 py-2.5 text-sm font-medium text-gray-700 hover:bg-gray-50"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={updateMutation.isPending}
+            className="inline-flex items-center gap-2 rounded-lg bg-brand-600 px-4 py-2.5 text-sm font-medium text-white hover:bg-brand-700 disabled:opacity-50"
+          >
+            {updateMutation.isPending ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <Save className="h-4 w-4" />
+            )}
+            Save Changes
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/packages/client/src/routes/offers.routes.tsx
+++ b/packages/client/src/routes/offers.routes.tsx
@@ -10,6 +10,9 @@ const OfferDetailPage = lazy(() =>
 const OfferCreatePage = lazy(() =>
   import("@/pages/offers/OfferCreatePage").then((m) => ({ default: m.OfferCreatePage })),
 );
+const OfferEditPage = lazy(() =>
+  import("@/pages/offers/OfferEditPage").then((m) => ({ default: m.OfferEditPage })),
+);
 const OfferLetterTemplatePage = lazy(() =>
   import("@/pages/offers/OfferLetterTemplatePage").then((m) => ({ default: m.OfferLetterTemplatePage })),
 );
@@ -19,6 +22,7 @@ export const offerRoutes = (
     <Route path="/offers" element={<OfferListPage />} />
     <Route path="/offers/new" element={<OfferCreatePage />} />
     <Route path="/offers/letter-templates" element={<OfferLetterTemplatePage />} />
+    <Route path="/offers/:id/edit" element={<OfferEditPage />} />
     <Route path="/offers/:id" element={<OfferDetailPage />} />
   </>
 );

--- a/packages/server/src/api/routes/organization.routes.ts
+++ b/packages/server/src/api/routes/organization.routes.ts
@@ -3,6 +3,7 @@
 // Read-only endpoints into the EmpCloud master DB for UI dropdowns etc.
 // - GET /departments — list active departments for the current org
 // - GET /locations   — list active locations for the current org
+// - GET /users       — list active users for the current org (approver pickers)
 // ============================================================================
 
 import { Router, Request, Response, NextFunction } from "express";
@@ -36,6 +37,21 @@ router.get("/locations", async (req: Request, res: Response, next: NextFunction)
       .where({ organization_id: req.user!.empcloudOrgId, is_active: true })
       .select("id", "name", "address", "timezone")
       .orderBy("name", "asc");
+    sendSuccess(res, rows);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// GET /users — list active users for the caller's organization.
+// Used by approver pickers (offer approval, etc.).
+router.get("/users", async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const db = getEmpCloudDB();
+    const rows = await db("users")
+      .where({ organization_id: req.user!.empcloudOrgId, status: 1 })
+      .select("id", "first_name", "last_name", "email", "role", "designation")
+      .orderBy("first_name", "asc");
     sendSuccess(res, rows);
   } catch (err) {
     next(err);


### PR DESCRIPTION
## Summary
Addresses both issues reported on the Offer Detail page.

- **#21** — Edit button and Submit for Approval button were both non-functional
- **#22** — Generate Offer Letter button appeared to crash the page to blank

## Fixes

### #21 - Edit button
Previously linked to `/offers/:id` (i.e. itself). Now routes to `/offers/:id/edit` and renders a new **OfferEditPage** that:
- Loads the existing offer
- Lets the user edit title, department, salary, joining/expiry dates, benefits, and notes
- Submits via `PUT /offers/:id` (backend already had `updateOffer` service; enforces draft-only edits)
- Redirects back to the detail page on success

### #21 - Submit for Approval button
Previously POSTed `{ approver_ids: [] }`, which the server rejects with *"At least one approver is required"* - and the mutation had no onError handler so nothing surfaced.

- New modal approver picker (backed by **`GET /organizations/users`**) lets HR check one or more org users before submitting
- Real approver IDs are sent
- onError toast wired so any future backend rejections are visible

### #22 - Generate Offer Letter crash
The Approval Workflow sidebar calls `offer.approvers.length` directly on a field that could be undefined in edge cases (API shape drift or older rows). That throws during render and blanks the whole subtree. Guarded both `.length` and `.map` accessors with `Array.isArray` / `?? []` so the page always renders.

## Files
- `packages/server/src/api/routes/organization.routes.ts` (new, adds `/users`; also includes `/departments` + `/locations` for UI-dropdown parity with PR #39)
- `packages/server/src/index.ts` - mount `/organizations`
- `packages/client/src/pages/offers/OfferEditPage.tsx` (new)
- `packages/client/src/routes/offers.routes.tsx` - add `/offers/:id/edit`
- `packages/client/src/pages/offers/OfferDetailPage.tsx` - Edit link, approver modal, defensive approvers rendering

Note: this PR's `organization.routes.ts` shares a filename with PR #39 (which introduced `/departments` + `/locations`). The content is a strict superset - one route file with all three endpoints. When both land, either merge order resolves cleanly by keeping this branch's superset.

## Test plan
- [ ] `/offers/:id` (draft) -> click **Edit** -> OfferEditPage loads with current values -> change a field -> Save -> back on detail with updated values
- [ ] Try to access `/offers/:id/edit` for a non-draft offer -> blocked with an amber notice
- [ ] `/offers/:id` (draft) -> **Submit for Approval** -> modal opens with org users -> pick one or more -> Submit -> offer status -> `pending_approval`, approvers listed in sidebar
- [ ] Submit with none selected -> toast "Please pick at least one approver"; no request
- [ ] Detail page loads for an offer with `approvers` missing (edge case) -> no blank page; renders "No approvers assigned yet"
- [ ] Generate Offer Letter flow unchanged where it was working; page no longer blanks on edge-case data

Closes #21
Closes #22
