### PR TITLE
fix(offers): department as dropdown on Offer Create (with free-text fallback)

### DIFF
--- a/packages/client/src/pages/offers/OfferCreatePage.tsx
+++ b/packages/client/src/pages/offers/OfferCreatePage.tsx
@@ -1,10 +1,12 @@
-import { useState } from "react";
+import { useState, useMemo } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { ArrowLeft, Save, Loader2, Search } from "lucide-react";
 import { apiGet, apiPost } from "@/api/client";
 import toast from "react-hot-toast";
 import type { Application, PaginatedResponse } from "@emp-recruit/shared";
+
+interface DepartmentOption { id: number; name: string }
 
 type ApplicationRow = Application & { candidate_name: string; job_title: string };
 
@@ -55,6 +57,17 @@ export function OfferCreatePage() {
       }),
   });
   const applications = appsData?.data?.data || [];
+
+  // #23 — department dropdown from the EmpCloud master DB. Falls back to
+  // free-text if the org hasn't configured any departments (or if the
+  // endpoint isn't available yet on the deployed backend).
+  const { data: departmentsData } = useQuery({
+    queryKey: ["org-departments"],
+    queryFn: () =>
+      apiGet<DepartmentOption[]>("/organizations/departments").catch(() => ({ data: [] as DepartmentOption[] })),
+    retry: false,
+  });
+  const departments = useMemo(() => departmentsData?.data ?? [], [departmentsData]);
 
   const createMutation = useMutation({
     mutationFn: (data: Record<string, any>) => apiPost<{ id: string }>("/offers", data),
@@ -214,13 +227,29 @@ export function OfferCreatePage() {
             </div>
             <div>
               <label className="block text-sm font-medium text-gray-700 mb-1">Department</label>
-              <input
-                type="text"
-                value={form.department}
-                onChange={(e) => setForm((p) => ({ ...p, department: e.target.value }))}
-                placeholder="e.g. Engineering"
-                className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm placeholder:text-gray-400 focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500"
-              />
+              {/* #23 — dropdown when the org has entries; free-text fallback
+                  so new tenants (or older deploys without /organizations/
+                  departments) aren't blocked. */}
+              {departments.length > 0 ? (
+                <select
+                  value={form.department}
+                  onChange={(e) => setForm((p) => ({ ...p, department: e.target.value }))}
+                  className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500"
+                >
+                  <option value="">Select department</option>
+                  {departments.map((d) => (
+                    <option key={d.id} value={d.name}>{d.name}</option>
+                  ))}
+                </select>
+              ) : (
+                <input
+                  type="text"
+                  value={form.department}
+                  onChange={(e) => setForm((p) => ({ ...p, department: e.target.value }))}
+                  placeholder="e.g. Engineering"
+                  className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm placeholder:text-gray-400 focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500"
+                />
+              )}
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
Fixes **#23** - the Department field on `/offers/new` was a free-text input.

## Fix
Swap to a dropdown sourced from `/organizations/departments`; if the endpoint returns an empty list or 404s (e.g. not yet deployed), fall back to the original free-text input so the form remains usable regardless of deploy order.

The backend endpoint lives in PR #39 (initial introduction) and PR #42 (added `/users` alongside it). This PR is order-independent: the `.catch(() => empty)` guard on the query keeps it safe if neither has merged yet.

## Files
- `packages/client/src/pages/offers/OfferCreatePage.tsx` (+29 / -8)

## Test plan
- [ ] `/offers/new` with `/organizations/departments` returning configured departments -> Department is a `<select>` populated from the list
- [ ] Empty / missing endpoint -> Department falls back to free-text (no regression)

Closes #23
