### PR TITLE
fix(onboarding): templates list — no more stray "0" next to empty templates

### DIFF
--- a/packages/client/src/pages/onboarding/OnboardingTemplatesPage.tsx
+++ b/packages/client/src/pages/onboarding/OnboardingTemplatesPage.tsx
@@ -275,7 +275,14 @@ export function OnboardingTemplatesPage() {
                       <p className="mt-0.5 text-sm text-gray-500">{template.description}</p>
                     )}
                   </div>
-                  <span className="text-sm text-gray-500">{template.task_count} tasks</span>
+                  {/* #24 — show a friendly "No tasks" label instead of a bare
+                      "0 tasks" string that rendered as a stray "0" in the
+                      card header. Only count + label when > 0. */}
+                  <span className="text-sm text-gray-500">
+                    {template.task_count > 0
+                      ? `${template.task_count} task${template.task_count === 1 ? "" : "s"}`
+                      : "No tasks"}
+                  </span>
                   <button
                     onClick={() => startEdit(template)}
                     className="rounded p-1.5 text-gray-400 hover:bg-gray-100 hover:text-gray-600 transition-colors"


### PR DESCRIPTION
## Summary
Fixes **#24** - a stray "0" appeared next to onboarding templates with no tasks yet.

The card header always rendered `{task_count} tasks`, so templates with zero tasks showed "0 tasks" in small gray text right after the template name, reading like a dangling "0".

## Fix
Render "No tasks" when `task_count === 0`, otherwise the number plus a pluralized label ("1 task" / "N tasks").

## Files
- `packages/client/src/pages/onboarding/OnboardingTemplatesPage.tsx` (+8 / -1)

## Test plan
- [ ] Template with 0 tasks -> card shows "No tasks"
- [ ] Template with 1 task -> "1 task"
- [ ] Template with N > 1 tasks -> "N tasks"

Closes #24
