### PR TITLE
fix(candidates): View Resume link no longer 404s in dev

### DIFF
--- a/packages/client/src/pages/candidates/CandidateDetailPage.tsx
+++ b/packages/client/src/pages/candidates/CandidateDetailPage.tsx
@@ -173,12 +173,22 @@ export function CandidateDetailPage() {
             </div>
           </div>
 
-          {/* Resume */}
+          {/* Resume — #27 — the server stores resume_path as e.g.
+              "/uploads/resumes/<file>" (leading-slash relative). In dev
+              the Vite server now proxies /uploads to the backend. The
+              extra normalization below is belt-and-braces for paths that
+              were stored without a leading slash. */}
           {candidate.resume_path && (
             <div className="rounded-lg border border-gray-200 bg-white p-6">
               <h2 className="text-sm font-medium text-gray-500 uppercase tracking-wider mb-3">Resume</h2>
               <a
-                href={candidate.resume_path}
+                href={
+                  /^https?:\/\//.test(candidate.resume_path)
+                    ? candidate.resume_path
+                    : candidate.resume_path.startsWith("/")
+                      ? candidate.resume_path
+                      : "/" + candidate.resume_path
+                }
                 target="_blank"
                 rel="noopener noreferrer"
                 className="inline-flex items-center gap-2 rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"

--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -19,6 +19,13 @@ export default defineConfig({
         target: "http://localhost:4500",
         changeOrigin: true,
       },
+      // #27 — static uploads (resumes, offer letters) are served from the
+      // backend at /uploads. Without this proxy, <a href="/uploads/...">
+      // resolves to the Vite origin and 404s.
+      "/uploads": {
+        target: "http://localhost:4500",
+        changeOrigin: true,
+      },
     },
   },
 });


### PR DESCRIPTION
## Summary
Fixes **#27** — clicking **View Resume** on a candidate detail page opened a 404 "page not found".

## Root cause
`candidate.resume_path` is stored by the backend upload middleware as `/uploads/resumes/<file>`. The frontend links to that path directly. In dev, the Vite server (port 5179) resolves the relative path against its own origin; it only proxies `/api`, not `/uploads`, so the request hits Vite and 404s. Production (single origin behind a reverse proxy) serves `/uploads` on the same host, so it was fine there.

## Fix
- **Vite dev proxy** - forward `/uploads` to `http://localhost:4500` alongside `/api`. Dev-only change; no production impact.
- **Frontend href normalization** in `CandidateDetailPage` - if `resume_path` is already an absolute URL (future pre-signed links), use as-is; otherwise ensure a leading slash before linking.

## Files
- `packages/client/vite.config.ts` (+8)
- `packages/client/src/pages/candidates/CandidateDetailPage.tsx` (+13 / -2)

## Test plan
- [ ] Upload a resume to a candidate
- [ ] Open the candidate detail page -> click **View Resume** -> PDF/doc opens in a new tab
- [ ] Absolute URL stored in `resume_path` (future case) -> opens as-is
- [ ] `resume_path` stored without leading slash -> still resolves correctly

Closes #27
