### PR TITLE
fix(jobs): remote_policy is now persisted and rendered everywhere

### DIFF
--- a/packages/client/src/pages/jobs/JobDetailPage.tsx
+++ b/packages/client/src/pages/jobs/JobDetailPage.tsx
@@ -303,6 +303,12 @@ export function JobDetailPage() {
               <span className="inline-flex items-center gap-1 capitalize">
                 <Clock className="h-4 w-4" /> {job.employment_type.replace(/_/g, " ")}
               </span>
+              {/* #32 — remote policy chip next to employment type */}
+              {(job as any).remote_policy && (
+                <span className="inline-flex items-center rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600 capitalize">
+                  {(job as any).remote_policy === "onsite" ? "On-site" : (job as any).remote_policy}
+                </span>
+              )}
               {(job.salary_min || job.salary_max) && (
                 <span className="inline-flex items-center gap-1">
                   {/* #1359 — Show the currency's actual symbol, not always $ */}

--- a/packages/client/src/pages/jobs/JobFormPage.tsx
+++ b/packages/client/src/pages/jobs/JobFormPage.tsx
@@ -83,7 +83,8 @@ export function JobFormPage() {
         salary_min: j.salary_min?.toString() ?? "",
         salary_max: j.salary_max?.toString() ?? "",
         salary_currency: j.salary_currency,
-        remote_policy: "onsite", // default, can be extended
+        // #30 — preserve whatever the server has stored; default only if missing
+        remote_policy: (j as any).remote_policy || "onsite",
         requirements: j.requirements ?? "",
         benefits: j.benefits ?? "",
         skills: j.skills
@@ -149,6 +150,8 @@ export function JobFormPage() {
       description: form.description,
       employment_type: form.employment_type,
       salary_currency: form.salary_currency,
+      // #30 — always persist remote_policy; previously dropped on the floor.
+      remote_policy: form.remote_policy,
     };
 
     if (form.department) payload.department = form.department;

--- a/packages/client/src/pages/jobs/JobListPage.tsx
+++ b/packages/client/src/pages/jobs/JobListPage.tsx
@@ -169,7 +169,13 @@ export function JobListPage() {
                     )}
                   </td>
                   <td className="px-6 py-4 text-sm text-gray-500 capitalize">
-                    {job.employment_type.replace(/_/g, " ")}
+                    {/* #32 — show remote policy next to employment type. */}
+                    <span className="block">{job.employment_type.replace(/_/g, " ")}</span>
+                    {(job as any).remote_policy && (
+                      <span className="mt-0.5 inline-flex items-center rounded-full bg-gray-100 px-2 py-0.5 text-[11px] font-medium text-gray-600 capitalize">
+                        {(job as any).remote_policy === "onsite" ? "On-site" : (job as any).remote_policy}
+                      </span>
+                    )}
                   </td>
                   <td className="px-6 py-4">
                     <span

--- a/packages/server/src/db/migrations/sql/009_job_postings_remote_policy.ts
+++ b/packages/server/src/db/migrations/sql/009_job_postings_remote_policy.ts
@@ -1,0 +1,30 @@
+// ============================================================================
+// MIGRATION 009 — Add remote_policy to job_postings
+// ============================================================================
+// The Job Create form has had a Remote Policy select from day one
+// (onsite / remote / hybrid) but the value was silently dropped: no
+// column in the DB, no field in the zod schema, no SELECT in the list
+// response. That's the root of #30 (field "always selects On-site" — it
+// doesn't actually store anything) and #32 (field doesn't appear on
+// the job card — because it was never stored).
+// ============================================================================
+
+import type { Knex } from "knex";
+
+export async function up(knex: Knex): Promise<void> {
+  const hasColumn = await knex.schema.hasColumn("job_postings", "remote_policy");
+  if (!hasColumn) {
+    await knex.schema.alterTable("job_postings", (t) => {
+      t.string("remote_policy", 20).notNullable().defaultTo("onsite");
+    });
+  }
+}
+
+export async function down(knex: Knex): Promise<void> {
+  const hasColumn = await knex.schema.hasColumn("job_postings", "remote_policy");
+  if (hasColumn) {
+    await knex.schema.alterTable("job_postings", (t) => {
+      t.dropColumn("remote_policy");
+    });
+  }
+}

--- a/packages/server/src/services/job/job.service.ts
+++ b/packages/server/src/services/job/job.service.ts
@@ -56,6 +56,7 @@ export async function createJob(
     hiring_manager_id?: number;
     max_applications?: number;
     closes_at?: string;
+    remote_policy?: string;
   },
   createdBy: number,
 ): Promise<JobPosting> {
@@ -84,6 +85,7 @@ export async function createJob(
     hiring_manager_id: data.hiring_manager_id ?? null,
     max_applications: data.max_applications ?? null,
     closes_at: data.closes_at ?? null,
+    remote_policy: data.remote_policy ?? "onsite",
     created_by: createdBy,
   };
 

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -142,6 +142,7 @@ export interface JobPosting {
   created_by: number;
   created_at: string;
   updated_at: string;
+  remote_policy: string; // onsite | remote | hybrid (#30, #32)
 }
 
 export interface Candidate {

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -57,6 +57,9 @@ export const createJobSchema = z.object({
   skills: z.array(z.string()).optional(),
   hiring_manager_id: z.number().int().optional(),
   max_applications: z.number().int().min(1).optional(),
+  // #30 — remote policy (onsite / remote / hybrid). The frontend form has
+  // always had this select; now it actually gets stored.
+  remote_policy: z.enum(["onsite", "remote", "hybrid"]).default("onsite"),
   // #1354 — Accept both ISO datetime and YYYY-MM-DD date strings
   closes_at: z
     .string()


### PR DESCRIPTION
## Summary
Fixes the pair of bugs caused by Remote Policy not actually being stored anywhere.

- **#30** - Remote Policy select "always selects On-site" no matter what the user picks
- **#32** - Remote Policy doesn't appear on job cards / detail page

## Root cause
The Job Create/Edit form has always had a Remote Policy `<select>` (onsite / remote / hybrid) but the field was silently dropped:
- No column in the `job_postings` table
- No `remote_policy` in `createJobSchema` (zod would strip unknown keys)
- No SELECT on list/detail responses

So the UI control was pure theater - submitting a value was a no-op, and the card couldn't render what was never stored.

## Changes

### Backend
- **Migration 009** adds `remote_policy VARCHAR(20) NOT NULL DEFAULT 'onsite'` to `job_postings` (idempotent via `hasColumn` guard, so it's safe to re-run on any env).
- `createJobSchema` gains `remote_policy: z.enum(["onsite", "remote", "hybrid"]).default("onsite")`.
- `createJob` service writes `remote_policy` to the new column.

### Shared types
- `JobPosting.remote_policy: string` added so clients pick it up automatically from the list/detail responses (which already SELECT *).

### Frontend
- **JobFormPage** sends `remote_policy` in the create/update payload and pre-fills from the existing value on edit (not the hardcoded default anymore).
- **JobListPage** shows a chip next to employment type.
- **JobDetailPage** shows a chip next to employment type.

## Files
- `packages/server/src/db/migrations/sql/009_job_postings_remote_policy.ts` (new, +30)
- `packages/shared/src/types/index.ts` (+1)
- `packages/shared/src/validators/index.ts` (+3)
- `packages/server/src/services/job/job.service.ts` (+2)
- `packages/client/src/pages/jobs/JobFormPage.tsx` (+3 / -1)
- `packages/client/src/pages/jobs/JobListPage.tsx` (+8 / -1)
- `packages/client/src/pages/jobs/JobDetailPage.tsx` (+6)

## Test plan
- [ ] Migration runs cleanly on a fresh DB and an existing one
- [ ] `/jobs/new` -> pick Remote -> Save -> redirected to detail -> detail shows "Remote" chip
- [ ] `/jobs` list -> card shows the chip next to employment type
- [ ] Edit existing job -> form pre-fills the saved remote policy (not always "onsite")
- [ ] Old jobs predating this change default to "onsite" (migration DEFAULT)

Closes #30
Closes #32
