### PR TITLE
fix(offers): Approve / Reject (and sibling) mutations surface errors

### DIFF
--- a/packages/client/src/pages/offers/OfferDetailPage.tsx
+++ b/packages/client/src/pages/offers/OfferDetailPage.tsx
@@ -92,32 +92,72 @@ export function OfferDetailPage() {
 
   const sendOffer = useMutation({
     mutationFn: () => apiPost(`/offers/${id}/send`),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["offer", id] }),
+    onSuccess: () => {
+      toast.success("Offer sent to candidate");
+      queryClient.invalidateQueries({ queryKey: ["offer", id] });
+    },
+    onError: (err: any) => {
+      toast.error(err?.response?.data?.error?.message || "Failed to send offer");
+    },
   });
 
   const revokeOffer = useMutation({
     mutationFn: () => apiPost(`/offers/${id}/revoke`),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["offer", id] }),
+    onSuccess: () => {
+      toast.success("Offer revoked");
+      queryClient.invalidateQueries({ queryKey: ["offer", id] });
+    },
+    onError: (err: any) => {
+      toast.error(err?.response?.data?.error?.message || "Failed to revoke offer");
+    },
   });
 
+  // #34 — approve/reject mutations previously had no onError handler, so
+  // a 403 ("You are not an approver for this offer") or 400 ("You have
+  // already acted on this offer") silently failed and the user thought
+  // the buttons were broken. Surface the server message via toast.
   const approveOffer = useMutation({
     mutationFn: (comment?: string) => apiPost(`/offers/${id}/approve`, { comment }),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["offer", id] }),
+    onSuccess: () => {
+      toast.success("Offer approved");
+      queryClient.invalidateQueries({ queryKey: ["offer", id] });
+    },
+    onError: (err: any) => {
+      toast.error(err?.response?.data?.error?.message || "Failed to approve offer");
+    },
   });
 
   const rejectOffer = useMutation({
     mutationFn: (comment?: string) => apiPost(`/offers/${id}/reject`, { comment }),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["offer", id] }),
+    onSuccess: () => {
+      toast.success("Offer rejected");
+      queryClient.invalidateQueries({ queryKey: ["offer", id] });
+    },
+    onError: (err: any) => {
+      toast.error(err?.response?.data?.error?.message || "Failed to reject offer");
+    },
   });
 
   const acceptOffer = useMutation({
     mutationFn: () => apiPost(`/offers/${id}/accept`),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["offer", id] }),
+    onSuccess: () => {
+      toast.success("Offer accepted");
+      queryClient.invalidateQueries({ queryKey: ["offer", id] });
+    },
+    onError: (err: any) => {
+      toast.error(err?.response?.data?.error?.message || "Failed to accept offer");
+    },
   });
 
   const declineOffer = useMutation({
     mutationFn: () => apiPost(`/offers/${id}/decline`),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["offer", id] }),
+    onSuccess: () => {
+      toast.success("Offer declined");
+      queryClient.invalidateQueries({ queryKey: ["offer", id] });
+    },
+    onError: (err: any) => {
+      toast.error(err?.response?.data?.error?.message || "Failed to decline offer");
+    },
   });
 
   // --- Offer Letter ---


### PR DESCRIPTION
## Summary
Fixes **#34** - Approve / Reject buttons on `/offers/:id` (pending approval) appeared to do nothing when clicked.

## Root cause
The Approve and Reject `useMutation` hooks had no `onError` handler. When the backend legitimately rejected the request (e.g. 403 *"You are not an approver for this offer"*, or 400 *"You have already acted on this offer"*), the error was silently swallowed and nothing surfaced - so users concluded the buttons were broken.

## Fix
- Add `onError` toast handlers to Approve / Reject (show the server message, fall back to a generic message).
- Add positive `onSuccess` toasts so users get confirmation ("Offer approved", "Offer rejected").
- Apply the same `onSuccess`/`onError` pattern to the four sibling action mutations on the same page (Send, Revoke, Accept, Decline) which had the same silent-failure issue.

## Files
- `packages/client/src/pages/offers/OfferDetailPage.tsx` (+40 / -6)

## Test plan
- [ ] Pending-approval offer, logged in as an approver on it -> Approve -> toast "Offer approved"; status flips
- [ ] Logged in as a non-approver HR -> Approve -> toast "You are not an approver for this offer" (server message shown)
- [ ] Approve twice -> second click shows "You have already acted on this offer"
- [ ] Same tests for Reject, Send, Revoke, Accept, Decline

Closes #34
